### PR TITLE
Search hotfix since you are unable to search again after searching once.

### DIFF
--- a/templates/search.php
+++ b/templates/search.php
@@ -13,7 +13,7 @@
               <div class="form-group">
                 <input type="text" class="form-control text-retro" id="search" placeholder="Search" value="{{ query }}">
               </div>
-              <button type="submit" class="btn btn-retro">Go</button>
+              <button type="submit" id="do_search" class="btn btn-retro">Go</button>
             </form>
         </div>
       </div>
@@ -37,5 +37,5 @@
   </div>
 </div>
 
-<script src="/js/search.js"></script>
+<script src="/js/home.js"></script>
 {% endblock %}


### PR DESCRIPTION
Hotfix found when attempting to search for someone having done so in the immediate past. Repeatable on the live site by searching for **[no profile]** in the search, then attempting to search for anything else (tested with **m4numbers**).

Fix basically joins the search page into the home.js family where searching is included functionality.
